### PR TITLE
Fix item index test to see if batteries image came through

### DIFF
--- a/spec/features/items/user_can_see_all_items_spec.rb
+++ b/spec/features/items/user_can_see_all_items_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Items index" do
 
         expect(page).to have_content(batteries.name)
         expect(page).to have_content(batteries.description)
-        # expect(page).to have_css("img[src*='#{batteries.image}']")
+        expect(page).to have_css("img[src*='batteries']")
         expect(page).to have_content(batteries.price)
         expect(page).to have_content(batteries.status)
         expect(page).to have_content(batteries.inventory)


### PR DESCRIPTION
'batteries' instead of more complete path name