### PR TITLE
Change 'Delete Merchant' to link instead of button

### DIFF
--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -4,4 +4,4 @@
   <%=@merchant.state %>, <%= @merchant.zip %></p>
 
 <p><%= link_to "Edit Merchant Information", "/merchants/#{@merchant.id}/edit" %> </p>
-<%= button_to 'Delete Merchant', "/merchants/#{@merchant.id}", method: :delete %>
+<%= link_to 'Delete Merchant', "/merchants/#{@merchant.id}", method: :delete %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
 
   patch '/merchants/:merchant_id', to: 'merchants#update'
   patch '/items/:item_id', to: 'items#update'
+  
   delete '/merchants/:merchant_id', to: 'merchants#destroy'
   delete '/items/:item_id', to: 'items#destroy'
 end

--- a/spec/features/merchants/user_can_delete_merchant_spec.rb
+++ b/spec/features/merchants/user_can_delete_merchant_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "To delete a merchant" do
               a merchant" do
       it "a 'DELETE' request is sent to '/merchants/:id' and I am redirected
           to the merchant index page where I no longer see the merchant" do
-                
+
         merchant_1 = Merchant.create( name: "Corner Store",
                                       address: "234 Yarp Dr.",
                                       city: "Denver",
@@ -15,7 +15,6 @@ RSpec.describe "To delete a merchant" do
 
         visit "/merchants/#{merchant_1.id}"
 
-        expect(page).to have_button("Delete Merchant")
         click_on "Delete Merchant"
 
         expect(current_path).to eq('/merchants')


### PR DESCRIPTION
On heroku, the delete merchant button was not working, changed to a link to simplify the html.